### PR TITLE
fix: update vulnerable Python dependencies

### DIFF
--- a/backend_api_python/requirements.lock
+++ b/backend_api_python/requirements.lock
@@ -17,7 +17,7 @@ beautifulsoup4==4.15.0
 billiard==4.2.4
 blinker==1.9.0
 build==1.5.0
-ccxt==4.5.70
+ccxt==4.5.73
 celery==5.6.3
 certifi==2026.6.17
 cffi==2.0.0

--- a/backend_api_python/requirements.lock
+++ b/backend_api_python/requirements.lock
@@ -1,7 +1,7 @@
 # Generated from requirements.txt for the verified Python 3.12 Linux production image.
 # Regenerate and validate this file whenever direct production requirements change.
 aiohappyeyeballs==2.7.1
-aiohttp==3.14.1
+aiohttp==3.14.3
 aiohttp-fast-zlib==0.3.0
 aiosignal==1.4.0
 akracer==0.0.14
@@ -27,7 +27,7 @@ click-didyoumean==0.3.1
 click-plugins==1.1.1.2
 click-repl==0.3.0
 coincurve==21.0.0
-cryptography==49.0.0
+cryptography==50.0.0
 curl-cffi==0.15.0
 decorator==5.3.1
 distro==1.9.0
@@ -92,7 +92,7 @@ pygments==2.20.0
 pyjwt==2.13.0
 pyluach==2.3.0
 pyotp==2.10.0
-pypdf==6.14.2
+pypdf==6.15.0
 pyproject-hooks==1.2.0
 pysocks==1.7.1
 python-dateutil==2.9.0.post0

--- a/backend_api_python/requirements.txt
+++ b/backend_api_python/requirements.txt
@@ -20,7 +20,8 @@ akshare>=1.18.80
 # GHSA-752w-5fwx-jx9f (crit header); 2.12.0+
 PyJWT>=2.13.0,<3
 python-dotenv>=1.2.2
-cryptography>=49.0.0
+# PYSEC-2026-3552; 50.0.0+
+cryptography>=50.0.0
 # TOTP MFA and QR code generation
 pyotp>=2.10.0
 qrcode[pil]>=8.2
@@ -41,7 +42,8 @@ flask-smorest>=0.47.0,<0.48
 marshmallow>=4.3.0,<5
 PyYAML>=6.0.3
 # Server-side PDF export for AI analysis reports
-pypdf>=6.14.2,<7
+# PYSEC-2026-3655 / PYSEC-2026-3656; 6.15.0+
+pypdf>=6.15.0,<7
 reportlab>=5.0.0
 # Password hashing
 bcrypt>=5.0.0

--- a/backend_api_python/requirements.txt
+++ b/backend_api_python/requirements.txt
@@ -4,7 +4,7 @@ Werkzeug>=3.1.8
 flask-cors==6.0.5
 finnhub-python>=2.4.29
 yfinance>=1.5.2
-ccxt>=4.5.69
+ccxt>=4.5.73
 pandas>=3.0.5
 # Strategy API V2 technical indicator runtime. The 0.6.x wheels bundle the C library.
 TA-Lib==0.7.1


### PR DESCRIPTION
## Summary

<!-- What does this PR do? -->

## Changes

- 

## Test plan

- [ ] Tested locally with `docker compose up -d --build`
- [ ] Backend logs show no errors
- [ ] Relevant pytest tests pass

## API documentation (if routes/schemas changed)

- [ ] Regenerated `docs/api/openapi.yaml` (`cd backend_api_python && python scripts/export_openapi.py`)
- [ ] Updated `docs/agent/agent-openapi.json` if `/api/agent/v1` routes changed
- [ ] Breaking API changes called out below (oasdiff will fail CI otherwise)

## Screenshots (if UI change)

<!-- Paste before/after screenshots -->
