### PR TITLE
fix: drop unexpected market_type kwarg at LiveOrderPhaseAdapter call site

### DIFF
--- a/backend_api_python/app/services/pending_order_worker.py
+++ b/backend_api_python/app/services/pending_order_worker.py
@@ -2094,7 +2094,6 @@ class PendingOrderWorker(PendingOrderPositionSyncMixin):
             adapter = LiveOrderPhaseAdapter(
                 client=client,
                 exchange_id=exchange_id,
-                market_type=market_type,
                 payload=payload,
                 exchange_config=exchange_config,
                 order_mode=order_mode,


### PR DESCRIPTION
## Summary

Strategy-generated live orders crash at final placement with `TypeError: LiveOrderPhaseAdapter.__init__() got an unexpected keyword argument 'market_type'`, so **every live auto-order (all exchanges, spot and swap) has failed since d169c03 (2026-08-27)**. The commit added `market_type=` to the `LiveOrderPhaseAdapter(...)` call, but the class never accepted that parameter. This PR removes the stray kwarg.

## Root cause

- d169c03 ("refactor: unify exchange instrument rules") modified the call site in `pending_order_worker.py` but not the adapter class (`live_trading/adapters.py`, last changed 2026-07-22).
- The adapter takes `market_type` from the `OrderIntent` in every method (`place_market_order` / `place_limit_order` / `cancel_order` / `wait_for_fill`), so the kwarg was not only unexpected but also unused — removing it from the call site is behavior-preserving.
- No test covers this call site (`test_live_exchange_fees.py` constructs the adapter without the kwarg), and the failure path is only reachable through live auto-trading, which is why it went unnoticed.

Observed in production logs:

```
Unexpected order error (binance BNB/USDT open_long): LiveOrderPhaseAdapter.__init__() got an unexpected keyword argument 'market_type'
```

## Changes

- `backend_api_python/app/services/pending_order_worker.py`: remove the single unexpected `market_type=market_type,` line from the `LiveOrderPhaseAdapter(...)` call. 1 line, nothing else.

## Test plan

- [x] `python -m py_compile backend_api_python/app/services/pending_order_worker.py`
- [x] Reproduced the TypeError on `21f1fb6` with the exact worker kwargs; confirmed the adapter constructs cleanly after removing the kwarg
- [x] Deployed locally (docker image rebuilt): the previously crashing BNB/USDT open_short (swap) + open_long (spot) strategy orders now pass the placement phase and reach the exchange

## API documentation

- [x] No route/schema changes — no OpenAPI regeneration needed.

## Backward compatibility

- Fully backward compatible; restores pre-d169c03 behavior.
