### PR TITLE
fix: infer Bybit, Bitget and Binance precision from Decimal exponent

### DIFF
--- a/backend_api_python/app/services/live_trading/binance_spot.py
+++ b/backend_api_python/app/services/live_trading/binance_spot.py
@@ -162,11 +162,12 @@ class BinanceSpotClient(BaseRestClient):
         if st <= 0:
             return None
         try:
-            normalized = st.normalize()
-            step_str = str(normalized)
-            if "." in step_str:
-                return min(18, max(0, len(step_str.split(".")[1])))
-            return 0
+            # normalize() renders small steps in scientific notation ("1E-8"),
+            # so derive the decimal places from the exponent instead.
+            exp = st.normalize().as_tuple().exponent
+            if not isinstance(exp, int):
+                return None
+            return min(18, max(0, -exp))
         except Exception:
             return None
 

--- a/backend_api_python/app/services/live_trading/bitget.py
+++ b/backend_api_python/app/services/live_trading/bitget.py
@@ -535,17 +535,9 @@ class BitgetMixClient(BaseRestClient):
             # Infer precision from step if not already set
             if size_precision is None:
                 try:
-                    step_normalized = step.normalize()
-                    step_str = str(step_normalized)
-                    if '.' in step_str:
-                        decimal_part = step_str.split('.')[1]
-                        size_precision = len(decimal_part)
-                        if size_precision < 0:
-                            size_precision = 0
-                        if size_precision > 18:
-                            size_precision = 18
-                    else:
-                        size_precision = 0
+                    exp = step.normalize().as_tuple().exponent
+                    if isinstance(exp, int):
+                        size_precision = min(max(0, -exp), 18)
                 except Exception:
                     pass
 
@@ -645,16 +637,9 @@ class BitgetMixClient(BaseRestClient):
             px = self._floor_to_step(px, step)
             if price_precision is None:
                 try:
-                    step_normalized = step.normalize()
-                    step_str = str(step_normalized)
-                    if "." in step_str:
-                        price_precision = len(step_str.split(".")[1])
-                        if price_precision < 0:
-                            price_precision = 0
-                        if price_precision > 18:
-                            price_precision = 18
-                    else:
-                        price_precision = 0
+                    exp = step.normalize().as_tuple().exponent
+                    if isinstance(exp, int):
+                        price_precision = min(max(0, -exp), 18)
                 except Exception:
                     pass
 

--- a/backend_api_python/app/services/live_trading/bybit.py
+++ b/backend_api_python/app/services/live_trading/bybit.py
@@ -528,21 +528,14 @@ class BybitClient(BaseRestClient):
         if step > 0:
             q = self._floor_to_step(q, step)
         
-        # Infer precision from qtyStep
+        # Infer precision from qtyStep. Decimal.normalize() renders small steps in
+        # scientific notation, so derive precision from the Decimal exponent.
         qty_precision = None
         if step > 0:
             try:
-                step_normalized = step.normalize()
-                step_str = str(step_normalized)
-                if '.' in step_str:
-                    decimal_part = step_str.split('.')[1]
-                    qty_precision = len(decimal_part)
-                    if qty_precision < 0:
-                        qty_precision = 0
-                    if qty_precision > 18:
-                        qty_precision = 18
-                else:
-                    qty_precision = 0
+                exp = step.normalize().as_tuple().exponent
+                if isinstance(exp, int):
+                    qty_precision = min(max(0, -exp), 18)
             except Exception:
                 pass
         
@@ -637,16 +630,9 @@ class BybitClient(BaseRestClient):
         price_precision = None
         if tick > 0:
             try:
-                tick_normalized = tick.normalize()
-                tick_str = str(tick_normalized)
-                if "." in tick_str:
-                    price_precision = len(tick_str.split(".")[1])
-                    if price_precision < 0:
-                        price_precision = 0
-                    if price_precision > 18:
-                        price_precision = 18
-                else:
-                    price_precision = 0
+                exp = tick.normalize().as_tuple().exponent
+                if isinstance(exp, int):
+                    price_precision = min(max(0, -exp), 18)
             except Exception:
                 pass
         return (p, price_precision)

--- a/backend_api_python/tests/test_step_precision_scientific_notation.py
+++ b/backend_api_python/tests/test_step_precision_scientific_notation.py
@@ -1,0 +1,71 @@
+"""Precision inference from exchange step sizes below 1E-6.
+
+Decimal.normalize() renders steps such as 0.0000001 as "1E-7". Parsing that
+string for a '.' misreads the precision as 0, which truncates prices and
+quantities to integers when they are rendered for the exchange.
+"""
+
+import time
+from decimal import Decimal
+
+from app.services.live_trading.binance_spot import BinanceSpotClient
+from app.services.live_trading.bitget import BitgetMixClient
+from app.services.live_trading.bybit import BybitClient
+
+
+def _bybit_client(price_tick: str, qty_step: str) -> BybitClient:
+    client = BybitClient(api_key="k", secret_key="s", category="linear")
+    client._inst_cache["linear:1000PEPEUSDT"] = (
+        time.time(),
+        {
+            "priceFilter": {"tickSize": price_tick},
+            "lotSizeFilter": {"qtyStep": qty_step, "minOrderQty": "0"},
+        },
+    )
+    return client
+
+
+def _bitget_client(contract: dict) -> BitgetMixClient:
+    client = BitgetMixClient.__new__(BitgetMixClient)
+    client._contract_cache = {}
+    client._contract_cache_ttl_sec = 300.0
+    client.get_contract = lambda **_kwargs: contract
+    return client
+
+
+def test_bybit_small_tick_keeps_price_decimals():
+    client = _bybit_client("0.0000001", "100")
+    price, precision = client._normalize_price(symbol="1000PEPE/USDT", price=0.01234567)
+    assert precision == 7
+    assert client._dec_str(price, strict_precision=precision) == "0.0123456"
+
+
+def test_bybit_small_qty_step_keeps_qty_decimals():
+    client = _bybit_client("0.01", "0.00000001")
+    qty, precision = client._normalize_qty(symbol="1000PEPE/USDT", qty=0.123456789)
+    assert precision == 8
+    assert client._dec_str(qty, strict_precision=precision) == "0.12345678"
+
+
+def test_bitget_small_price_step_keeps_price_decimals():
+    client = _bitget_client({"priceStep": "0.0000001"})
+    price, precision = client._normalize_price(
+        symbol="PEPE/USDT", product_type="USDT-FUTURES", price=0.01234567
+    )
+    assert precision == 7
+    assert client._dec_str(price, strict_precision=precision) == "0.0123456"
+
+
+def test_bitget_small_size_step_keeps_size_decimals():
+    client = _bitget_client({"sizeMultiplier": "0.00000001"})
+    size, precision = client._normalize_size(
+        symbol="BTC/USDT", product_type="USDT-FUTURES", base_size=0.123456789
+    )
+    assert precision == 8
+    assert client._dec_str(size, strict_precision=precision) == "0.12345678"
+
+
+def test_binance_decimal_places_from_small_step():
+    assert BinanceSpotClient._decimal_places_from_step(Decimal("0.00000001")) == 8
+    assert BinanceSpotClient._decimal_places_from_step(Decimal("0.00001000")) == 5
+    assert BinanceSpotClient._decimal_places_from_step(Decimal("10")) == 0


### PR DESCRIPTION
## Summary

The OKX client was fixed to infer lot precision from the Decimal exponent, because `Decimal.normalize()` turns small steps into scientific notation (`Decimal("0.0000001").normalize()` is `1E-7`, with no `.` in it). I found the same string parsing still in place in the Bybit and Bitget clients and in `BinanceSpotClient._decimal_places_from_step`, which the Binance futures client also uses. For any step or tick at 1E-7 or smaller, precision comes out as 0.

That value then goes to `_dec_str(..., strict_precision=0)`, which rounds down to an integer. Take Bybit linear with a `tickSize` of `0.0000001`: a limit price of `0.01234567` is sent as `"0"`. Quantities with an `0.00000001` step are cut the same way, and on Binance futures `min(quantityPrecision, 0)` keeps the 0.

## Changes

- `bybit.py`: `_normalize_qty` and `_normalize_price` get the precision from `step.normalize().as_tuple().exponent`, the same way `okx.py` already does
- `bitget.py`: same change in `_normalize_size` and `_normalize_price`, for the fallback used when `sizePlace` / `pricePlace` are missing
- `binance_spot.py`: `_decimal_places_from_step` uses the exponent too
- New `tests/test_step_precision_scientific_notation.py` with one case for each call site

Steps of 1E-6 or more and integer steps like `10` (`1E+1`, precision 0) give the same result as before, so nothing changes for the instruments that already worked.

## Test plan

- [ ] Tested locally with `docker compose up -d --build`
- [ ] Backend logs show no errors
- [x] Relevant pytest tests pass

Without the fix, all 5 new tests fail on the value itself (`assert 0 == 7`, `assert 0 == 8`). With it they pass, and the full `tests/` suite gives 2343 passed and 20 skipped (Python 3.12). `ruff check app scripts tests`, `scripts/backend_quality_check.py` and `scripts/check_mojibake.py` also pass. I didn't run the Docker stack because the change doesn't touch any route or config.

## API documentation (if routes/schemas changed)

No routes or schemas changed.

AI tools used
